### PR TITLE
Add GitHub Actions CI: data checks + frontend tests and asset-sync guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  data:
+    name: Python pipeline (mypy + pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: data/requirements.txt
+
+      # run_tests.sh looks for data/election_data first, then data/.venv.
+      - name: Install dependencies
+        working-directory: data
+        run: |
+          python -m venv .venv
+          ./.venv/bin/pip install -r requirements.txt
+
+      - name: mypy + pytest
+        working-directory: data
+        run: ./run_tests.sh
+
+  frontend:
+    name: Frontend (vitest + built-asset sync)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Vitest
+        run: npm test
+
+      # GitHub Pages serves the committed .min.js/.min.css/vendor bundles as-is
+      # (there is no build step at deploy time), so a source edit without a
+      # rebuild ships stale assets. Rebuild everything and fail on any drift.
+      - name: Check committed built assets are in sync with source
+        run: |
+          npm run vendor:d3
+          npm run minify:electionmaps
+          if ! git diff --exit-code; then
+            echo "::error::Committed built assets are stale. Run 'npm run vendor:d3 && npm run minify:electionmaps' and commit the result."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ node_modules/
 
 # ── Data & databases ──────────────────────────────────────────────────────────
 data/election_data/*
+data/.venv/
 data/*.db
 *.db-wal
 *.db-shm

--- a/data/mypy.ini
+++ b/data/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 strict = True
-python_version = 3.10
+python_version = 3.12
 files = ., models.py
 # old_data/ holds archived one-shot migration / boundary-import scripts that no
 # active code imports (some reference since-removed config attrs); not type-checked.

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -8,6 +8,8 @@ openpyxl>=3.1
 xlrd>=2.0
 pydantic>=2.0
 pydantic-settings>=2.0
-mypy>=1.9
+python-dotenv>=1.0
+mypy==2.1.0
+pytest>=8.0
 types-Flask
 types-beautifulsoup4


### PR DESCRIPTION
Two jobs on push to master and on PRs:
- data: fresh venv from requirements.txt, then run_tests.sh (strict mypy gate + pytest), same command as local.
- frontend: npm ci, vitest, then rebuild the committed bundles and fail on git diff — Pages serves the committed .min assets as-is, so a source edit without a rebuild would otherwise ship stale JS silently.

Fixes surfaced by simulating the fresh install: declare pytest and python-dotenv (both imported but undeclared), pin mypy==2.1.0 so local and CI agree, bump mypy python_version to 3.12 (numpy 2.5 ships PEP-695 type stubs that hard-error under a 3.10 target), and gitignore data/.venv which run_tests.sh already supports as a fallback.